### PR TITLE
hazelcast hibernate jpa 2nd level cache code sample

### DIFF
--- a/hibernate-jpa-2ndlevel-cache/Dockerfile
+++ b/hibernate-jpa-2ndlevel-cache/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:latest
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y maven \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y  software-properties-common && \
+    add-apt-repository ppa:webupd8team/java -y && \
+    apt-get update && \
+    echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+    apt-get install -y oracle-java8-installer && \
+    apt-get clean
+
+WORKDIR /hibernate-jpa-2ndlevel-cache
+ADD . /hibernate-jpa-2ndlevel-cache
+

--- a/hibernate-jpa-2ndlevel-cache/README.md
+++ b/hibernate-jpa-2ndlevel-cache/README.md
@@ -1,0 +1,93 @@
+<h1>Hibernate 2nd Level Cache with Hazelcast by using JPA</h1>
+
+In this repository, you can find a sample implementation of hibernate 2nd level cache with hazelcast by using JPA. You can also find detailed explanation at http://hazelcast.org/ 
+
+<h2>Prerequisites</h2>
+
+You should have installed Docker on your system.
+
+By default some dependencies added to project in "pom.xml" file as follows:
+```
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-hibernate3</artifactId>
+    <version>3.6.4</version>
+</dependency>
+
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast</artifactId>
+    <version>3.8.3</version>
+</dependency>
+
+<dependency>
+    <groupId>javassist</groupId>
+    <artifactId>javassist</artifactId>
+    <version>3.12.1.GA</version>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.derby</groupId>
+    <artifactId>derby</artifactId>
+    <version>10.10.2.0</version>
+</dependency>
+
+<dependency>
+    <groupId>org.hibernate</groupId>
+    <artifactId>hibernate-entitymanager</artifactId>
+    <version>3.6.9.Final</version>
+</dependency>
+
+<dependency>
+    <groupId>org.hibernate.javax.persistence</groupId>
+    <artifactId>hibernate-jpa-2.0-api</artifactId>
+    <version>1.0.0.Final</version>
+</dependency>
+```
+But project is also compatible with hibernate 3.X.X versions. You can change these entries accordingly.
+
+<h2>How to Run Sample Application</h2>
+
+1) Build project image using:
+```
+docker build -t hazelcast-jpa-2ndlevelcache .
+```
+2) Create database using:
+```
+docker run -it --rm  hazelcast-jpa-2ndlevelcache bash "./run.sh"
+```
+
+<h3>Sample Use Case</h3>
+
+Execute the following commands in ManageEmployeeJPA.
+
+```
+Command:
+add
+Id: 1
+First Name: Name
+Last Name: Surname
+Salary: 100
+list
+Id: 1 
+First Name: Name 
+Last Name: Surname 
+Salary: 100
+remove
+Key:
+1
+update
+Id: 1
+First Name: Name
+Last Name: Surname
+Salary: 100
+Key:
+1
+```
+
+After application running it creates sample db with 19 records (id range from 1 to 19).
+If execute 'show' command with id in range above you will not see any SQL statements in the console (cached entities).
+
+4) Also you may see Hibernate statistics via jconsole.
+
+

--- a/hibernate-jpa-2ndlevel-cache/pom.xml
+++ b/hibernate-jpa-2ndlevel-cache/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hibernate-jpa-2ndlevel-cache</artifactId>
+    <name>Hibernate JPA 2nd Level Cache</name>
+    <groupId>com.hazelcast.samples</groupId>
+    <version>0.1-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>3.8.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-hibernate3</artifactId>
+            <version>3.6.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>3.6.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <version>1.0.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.12.1.GA</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.10.2.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/hibernate-jpa-2ndlevel-cache/run.sh
+++ b/hibernate-jpa-2ndlevel-cache/run.sh
@@ -1,0 +1,3 @@
+mvn clean install
+mvn exec:java -Dexec.mainClass="com.hazelcast.hibernate.CreateTable" -Dexec.cleanupDaemonThreads=false
+mvn exec:java -Dexec.mainClass="com.hazelcast.hibernate.ManageEmployeeJPA"

--- a/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/CreateTable.java
+++ b/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/CreateTable.java
@@ -1,0 +1,31 @@
+package com.hazelcast.hibernate;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * @author tgrl
+ */
+public class CreateTable {
+
+    public static void main(String[] args) {
+        try {
+            Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Connection conn = DriverManager.getConnection("jdbc:derby:hibernateDB;create=true", new Properties());
+            Statement st = conn.createStatement();
+            st.executeUpdate("CREATE TABLE employee(id INT PRIMARY KEY NOT NULL"
+                    + ", first_name VARCHAR(20) default NULL"
+                    + ", last_name  VARCHAR(20) default NULL"
+                    + ", salary     INT         default NULL)");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/DropTable.java
+++ b/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/DropTable.java
@@ -1,0 +1,25 @@
+package com.hazelcast.hibernate;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class DropTable {
+
+    public static void main(String[] args) {
+        try {
+            Class.forName("org.apache.derby.jdbc.EmbeddedDriver").newInstance();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        try {
+            Connection conn = DriverManager.getConnection("jdbc:derby:hibernateDB;create=true", new Properties());
+            Statement st = conn.createStatement();
+            st.executeUpdate("DROP TABLE employee");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/Employee.java
+++ b/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/Employee.java
@@ -1,0 +1,72 @@
+package com.hazelcast.hibernate;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author tgrl
+ */
+@Entity
+@Cacheable
+@Table(name = "employee")
+@SuppressWarnings("unused")
+public class Employee {
+
+    @Id
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "salary")
+    private int salary;
+
+    public Employee() {
+    }
+
+    public Employee(int id, String fname, String lname, int salary) {
+        this.id = id;
+        this.firstName = fname;
+        this.lastName = lname;
+        this.salary = salary;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public int getSalary() {
+        return salary;
+    }
+
+    public void setSalary(int salary) {
+        this.salary = salary;
+    }
+}

--- a/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/ManageEmployeeJPA.java
+++ b/hibernate-jpa-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/ManageEmployeeJPA.java
@@ -1,0 +1,225 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import org.hibernate.SessionFactory;
+import org.hibernate.ejb.EntityManagerFactoryImpl;
+import org.hibernate.jmx.StatisticsService;
+import org.hibernate.stat.EntityStatistics;
+import org.hibernate.stat.QueryStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.Statistics;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * @author tgrl
+ */
+public class ManageEmployeeJPA {
+
+    public static final String FIRST_NAME = "John ";
+    public static final String LAST_NAME = "Dow ";
+    public static final int ENTRY_COUNT = 20;
+    public static final String SELECT_A_FROM_EMPLOYEE_A = "Select a from Employee a";
+    private static EntityManager em;
+    private static Statistics statistics;
+    private static HazelcastInstance hazelcast;
+
+    public static void main(String[] args) {
+        init();
+        populateDb();
+        processConsoleCommand();
+        Hazelcast.shutdownAll();
+    }
+
+    private static void populateDb() {
+        for (int i = 1; i < ENTRY_COUNT; i++) {
+            removeEmployee(i);
+            createEmployee(i, FIRST_NAME + i, LAST_NAME + i, i);
+        }
+    }
+
+    private static void init() {
+        EntityManagerFactory emf = Persistence.createEntityManagerFactory("hiberjpa");
+        em = emf.createEntityManager();
+        EntityManagerFactoryImpl emfi = (EntityManagerFactoryImpl) emf;
+        SessionFactory sessionFactory = emfi.getSessionFactory();
+        statistics = sessionFactory.getStatistics();
+        registerMBean(sessionFactory);
+        hazelcast = HazelcastAccessor.getHazelcastInstance(sessionFactory);
+    }
+
+    private static void registerMBean(SessionFactory sessionFactory) {
+        ArrayList<MBeanServer> list = MBeanServerFactory.findMBeanServer(null);
+        MBeanServer server = list.get(0);
+        try {
+            ObjectName objectName = new ObjectName("org.hibernate:name=HibernateStatistics");
+            StatisticsService mBean = new StatisticsService();
+            mBean.setSessionFactory(sessionFactory);
+            server.registerMBean(mBean, objectName);
+        } catch (MalformedObjectNameException e) {
+            e.printStackTrace();
+        } catch (InstanceAlreadyExistsException e) {
+            e.printStackTrace();
+        } catch (MBeanRegistrationException e) {
+            e.printStackTrace();
+        } catch (NotCompliantMBeanException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void processConsoleCommand() {
+        Scanner reader = new Scanner(System.in);
+        while (true) {
+            System.out.println("Command: ");
+            String command = reader.nextLine();
+            if (command.equals("list")) {
+                System.out.println("List: ");
+                listEmployee();
+            } else if (command.equals("add")) {
+                System.out.print("Id: ");
+                int id = reader.nextInt();
+                reader.nextLine();
+                System.out.print("First Name: ");
+                String fname = reader.nextLine();
+                System.out.print("Last Name: ");
+                String lname = reader.nextLine();
+                System.out.print("Salary: ");
+                int salary = reader.nextInt();
+                createEmployee(id, fname, lname, salary);
+            } else if (command.equals("remove")) {
+                System.out.println("Key: ");
+                int id = reader.nextInt();
+                removeEmployee(id);
+            } else if (command.equals("update")) {
+                System.out.print("Id: ");
+                int id = reader.nextInt();
+                reader.nextLine();
+                System.out.print("First Name: ");
+                String fname = reader.nextLine();
+                System.out.print("Last Name: ");
+                String lname = reader.nextLine();
+                System.out.print("Salary: ");
+                int salary = reader.nextInt();
+                System.out.print("Key: ");
+                int key = reader.nextInt();
+                updateEmployee(id, fname, lname, salary, key);
+            } else if (command.equals("show")) {
+                System.out.println("Key: ");
+                int id = reader.nextInt();
+                showEmployee(id);
+            } else if (command.equals("stats")) {
+                printStatistics();
+            } else if (command.endsWith("exit")) {
+                break;
+            } else {
+                System.err.println("Command not found: " + command);
+            }
+        }
+    }
+
+    private static void showEmployee(int id) {
+        Employee employee = em.find(Employee.class, id);
+        if (employee != null) {
+            printEmployee(employee);
+        } else {
+            System.out.println("not found");
+        }
+    }
+
+    private static void printStatistics() {
+        printHibernateStatistics();
+        printHazelcastStatistics();
+    }
+
+    private static void printHazelcastStatistics() {
+        IMap<Object, Object> map = hazelcast.getMap(Employee.class.getName());
+        System.out.println("Hazelcast.Map cache size is " + map.size() + " entries");
+    }
+
+    private static void printHibernateStatistics() {
+        String name = Employee.class.getName();
+
+        EntityStatistics entityStatistics = statistics.getEntityStatistics(name);
+        if (entityStatistics != null) {
+            System.out.println("Hibernate.EntityStatistics for " + name);
+            System.out.println(entityStatistics);
+        } else {
+            System.err.println("Hibernate.EntityStatistics null for " + name);
+        }
+
+        QueryStatistics queryStats = statistics.getQueryStatistics(SELECT_A_FROM_EMPLOYEE_A);
+        if (queryStats != null) {
+            System.out.println("Hibernate.QueryStatistics for " + SELECT_A_FROM_EMPLOYEE_A);
+            System.out.println(queryStats);
+        } else {
+            System.err.println("Hibernate.QueryStatistics null for " + SELECT_A_FROM_EMPLOYEE_A);
+        }
+
+        String regionName = "com.hazelcast.hibernate.Employee";
+        SecondLevelCacheStatistics cacheStats = statistics.getSecondLevelCacheStatistics(regionName);
+        if (cacheStats != null) {
+            System.out.println("Hibernate.SecondLevelCacheStatistics stats for " + regionName);
+            System.out.println(cacheStats);
+        } else {
+            System.err.println("Hibernate.SecondLevelCacheStatistics null for " + regionName);
+        }
+    }
+
+    private static void createEmployee(int id, String firstName, String lastName, int salary) {
+        Employee emp = new Employee(id, firstName, lastName, salary);
+        em.getTransaction().begin();
+        em.persist(emp);
+        em.getTransaction().commit();
+    }
+
+    private static void removeEmployee(int key) {
+        Employee employee = em.find(Employee.class, key);
+        if (employee != null) {
+            em.getTransaction().begin();
+            em.remove(employee);
+            em.getTransaction().commit();
+        }
+    }
+
+    private static void listEmployee() {
+        List<Employee> employeeList = em
+                .createQuery(SELECT_A_FROM_EMPLOYEE_A, Employee.class)
+                .getResultList();
+
+        for (Employee employee : employeeList) {
+            printEmployee(employee);
+        }
+    }
+
+    private static void printEmployee(Employee employee) {
+        System.out.println("ID: " + employee.getId());
+        System.out.println("First name: " + employee.getFirstName());
+        System.out.println("Last name: " + employee.getLastName());
+        System.out.println("Salary: " + employee.getSalary());
+    }
+
+    private static void updateEmployee(int id, String firstName, String lastName, int salary, int key) {
+        Employee employee = em.find(Employee.class, key);
+        em.getTransaction().begin();
+        employee.setId(id);
+        employee.setFirstName(firstName);
+        employee.setLastName(lastName);
+        employee.setSalary(salary);
+        em.getTransaction().commit();
+    }
+}

--- a/hibernate-jpa-2ndlevel-cache/src/main/resources/META-INF/persistence.xml
+++ b/hibernate-jpa-2ndlevel-cache/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+             version="1.0">
+
+    <persistence-unit name="hiberjpa" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <properties>
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.DerbyDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
+
+            <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="hibernate.cache.use_query_cache" value="true"/>
+            <property name="hibernate.cache.use_minimal_puts" value="true"/>
+            <property name="hibernate.cache.region.factory_class" value="com.hazelcast.hibernate.HazelcastCacheRegionFactory"/>
+            <property name="hibernate.cache.hazelcast.use_native_client" value="false"/>
+            <property name="hibernate.cache.hazelcast.native_client_hosts" value="127.0.0.1"/>
+            <property name="hibernate.cache.hazelcast.native_client_group" value="hibernate"/>
+            <property name="hibernate.cache.hazelcast.native_client_password" value="password"/>
+            <property name="hibernate.connection.driver_class" value="org.apache.derby.jdbc.EmbeddedDriver"/>
+            <property name="hibernate.connection.url" value="jdbc:derby:hibernateDB"/>
+            <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.cache.use_structured_entries" value="true"/>
+
+            <property name="javax.persistence.sharedCache.mode" value="ENABLE_SELECTIVE"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/hibernate-jpa-2ndlevel-cache/src/main/resources/hazelcast.xml
+++ b/hibernate-jpa-2ndlevel-cache/src/main/resources/hazelcast.xml
@@ -1,0 +1,114 @@
+<hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                               http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd"
+           xmlns="http://www.hazelcast.com/schema/config">
+
+    <group>
+        <name>hibernate</name>
+        <password>password</password>
+    </group>
+
+    <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+    <network>
+        <port auto-increment="true" port-count="100">5701</port>
+        <outbound-ports>
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <multicast enabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="false">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+            <aws enabled="false">
+                <access-key>my-access-key</access-key>
+                <secret-key>my-secret-key</secret-key>
+                <region>us-west-1</region>
+                <host-header>ec2.amazonaws.com</host-header>
+                <security-group-name>hazelcast-sg</security-group-name>
+                <tag-key>type</tag-key>
+                <tag-value>hz-nodes</tag-value>
+            </aws>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.10.1.*</interface>
+        </interfaces>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+        <symmetric-encryption enabled="false">
+            <algorithm>PBEWithMD5AndDES</algorithm>
+            <salt>thesalt</salt>
+            <password>thepass</password>
+            <iteration-count>19</iteration-count>
+        </symmetric-encryption>
+    </network>
+
+    <partition-group enabled="false"/>
+
+    <executor-service name="default">
+        <pool-size>16</pool-size>
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+
+    <queue name="default">
+        <max-size>0</max-size>
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+        <empty-queue-ttl>-1</empty-queue-ttl>
+    </queue>
+
+    <map name="default">
+        <in-memory-format>BINARY</in-memory-format>
+        <backup-count>1</backup-count>
+        <read-backup-data>false</read-backup-data>
+        <async-backup-count>0</async-backup-count>
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-idle-seconds>0</max-idle-seconds>
+        <eviction-policy>NONE</eviction-policy>
+        <max-size policy="PER_NODE">0</max-size>
+        <eviction-percentage>25</eviction-percentage>
+        <merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
+    </map>
+
+    <multimap name="default">
+        <backup-count>1</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <multimap name="default">
+        <backup-count>1</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <list name="default">
+        <backup-count>1</backup-count>
+    </list>
+
+    <set name="default">
+        <backup-count>1</backup-count>
+    </set>
+
+    <jobtracker name="default">
+        <max-thread-size>0</max-thread-size>
+        <!-- Queue size 0 means number of partitions * 2 -->
+        <queue-size>0</queue-size>
+        <retry-count>0</retry-count>
+        <chunk-size>1000</chunk-size>
+        <communicate-stats>true</communicate-stats>
+        <topology-changed-strategy>CANCEL_RUNNING_OPERATION</topology-changed-strategy>
+    </jobtracker>
+
+    <semaphore name="default">
+        <initial-permits>0</initial-permits>
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </semaphore>
+
+    <serialization>
+        <portable-version>0</portable-version>
+    </serialization>
+
+    <services enable-defaults="true"/>
+</hazelcast>


### PR DESCRIPTION
In this PR, we have additional two files, `run.sh` and `Dockerfile`. Rest of the changes are identical with the current hibernate-jpa-2ndlevel-cache code sample.

We have removed this part from pom.xml to get rid of dependency on parent project.
```
<parent>
  <artifactId>hazelcast-integration</artifactId>
  <groupId>com.hazelcast.samples</groupId>
  <version>0.1-SNAPSHOT</version>
  <relativePath>../pom.xml</relativePath>
</parent>
```
