### PR TITLE
Add a sample of MC image with built-in user

### DIFF
--- a/management-center-built-in-user/Dockerfile
+++ b/management-center-built-in-user/Dockerfile
@@ -1,0 +1,17 @@
+FROM hazelcast/management-center:latest
+
+# override start command for Management Center
+CMD ["bash", "-c", "set -euo pipefail \
+      # define a built-in user account on first start
+      && [ -f ${MC_DATA}/security.properties ] || ${MC_HOME}/mc-cli.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
+      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
+      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
+      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
+      && echo \"########################################\" \
+      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
+      && echo \"# starting now....\" \
+      && echo \"########################################\" \
+      && set -x \
+      && exec java -server ${JAVA_OPTS} -jar ${MC_RUNTIME} \
+                ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_CONTEXT} \
+     "]

--- a/management-center-built-in-user/README.md
+++ b/management-center-built-in-user/README.md
@@ -1,0 +1,33 @@
+# Hazelcast Management Center With Built-In User Sample
+
+In this repository, you can find a sample Docker image for Hazelcast Management Center with a built-in user account.
+
+## Prerequisites
+
+You should have installed Docker on your System.
+
+## How to Build and Run Sample Image
+
+1. Clone repo into the local.
+ 
+ `git clone https://github.com/hazelcast/hazelcast-docker-samples.git`
+
+2. Go to directory;
+
+`cd hazelcast-docker-samples/management-center-built-in-user/`
+
+3. Build the image using the Docker command.
+
+`docker build -t mc-built-in-user .`
+
+4. Launch a container using the Docker command.
+
+`docker run -p 8080:8080 mc-built-in-user`
+
+5. Open a browser and enter:
+
+`http://localhost:8080/hazelcast-mancenter`
+
+5. Login with this credentials:
+
+Username: `admin` Password: `p@ssw0rd`


### PR DESCRIPTION
Depends on `mc-cli.sh` availability in Management Center's download .zip (planned for 3.12).

Had to copy CMD from the MC base image. If the base image had an entrypoint (an .sh script), it could be reused.