### PR TITLE
Change mc-cli.sh to mc-conf.sh in MC image with built-in user

### DIFF
--- a/management-center-built-in-user/Dockerfile
+++ b/management-center-built-in-user/Dockerfile
@@ -3,7 +3,7 @@ FROM hazelcast/management-center:latest
 # override start command for Management Center
 CMD ["bash", "-c", "set -euo pipefail \
       # define a built-in user account on first start
-      && [ -f ${MC_DATA}/security.properties ] || ${MC_HOME}/mc-cli.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
+      && [ -f ${MC_DATA}/security.properties ] || ${MC_HOME}/mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
       && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
       && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
       && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \


### PR DESCRIPTION
Reason: renaming MC CLI tool into MC Configuration tool (MC Conf)

Follow-up for #14 