### PR TITLE
Fix mc-conf.sh not found in MC built-in user sample

### DIFF
--- a/management-center-built-in-user/Dockerfile
+++ b/management-center-built-in-user/Dockerfile
@@ -1,19 +1,8 @@
 FROM hazelcast/management-center:latest
 
-ENV MC_BIN_DIR="${MC_HOME}/hazelcast-management-center-${MC_VERSION}"
-
-# override start command for Management Center
+# Start Management Center
 CMD ["bash", "-c", "set -euo pipefail \
-      # define a built-in user account on first start
-      && [ -f ${MC_DATA}/security.properties ] || (cd ${MC_BIN_DIR} && ${MC_BIN_DIR}/mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin) \
-      && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
-      && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
-      && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \
-      && echo \"########################################\" \
-      && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
-      && echo \"# starting now....\" \
-      && echo \"########################################\" \
-      && set -x \
-      && exec java -server ${JAVA_OPTS} -jar ${MC_RUNTIME} \
-                ${MC_HTTP_PORT} ${MC_HTTPS_PORT} ${MC_CONTEXT} \
+      # define a built-in user account on first start (if security.properties file is not present)
+      && [ -f ${MC_DATA}/security.properties ] || ./mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
+      && /mc-start.sh \
      "]

--- a/management-center-built-in-user/Dockerfile
+++ b/management-center-built-in-user/Dockerfile
@@ -1,9 +1,11 @@
 FROM hazelcast/management-center:latest
 
+ENV MC_BIN_DIR="${MC_HOME}/hazelcast-management-center-${MC_VERSION}"
+
 # override start command for Management Center
 CMD ["bash", "-c", "set -euo pipefail \
       # define a built-in user account on first start
-      && [ -f ${MC_DATA}/security.properties ] || ${MC_HOME}/mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
+      && [ -f ${MC_DATA}/security.properties ] || (cd ${MC_BIN_DIR} && ${MC_BIN_DIR}/mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin) \
       && if [[ \"x${JAVA_OPTS}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT} ${JAVA_OPTS}\"; else export JAVA_OPTS=\"${JAVA_OPTS_DEFAULT}\"; fi \
       && if [[ \"x${MIN_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MIN_HEAP_SIZE}\"; fi \
       && if [[ \"x${MAX_HEAP_SIZE}\" != \"x\" ]]; then export JAVA_OPTS=\"${JAVA_OPTS} -Xms${MAX_HEAP_SIZE}\"; fi \


### PR DESCRIPTION
* Assumes upcoming updates in the base image. Thus it depends on https://github.com/hazelcast/management-center-docker/pull/12
* Fixes the following issue with starting MC built-in user sample image:
```
docker run -p 8080:8080 mc-built-in-user
bash: /opt/hazelcast/mancenter/mc-conf.sh: No such file or directory
```