### PR TITLE
Unmatched arguments from index 0: 'create-user' bug fix

### DIFF
--- a/management-center-built-in-user/Dockerfile
+++ b/management-center-built-in-user/Dockerfile
@@ -4,6 +4,6 @@ FROM hazelcast/management-center:latest
 # Start Management Center
 CMD ["bash", "-c", "set -euo pipefail \
       # define a built-in user account on first start (if security.properties file is not present)
-      && [ -f ${MC_DATA}/security.properties ] || ./mc-conf.sh create-user -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
+      && [ -f ${MC_DATA}/security.properties ] || ./mc-conf.sh user create -H=${MC_DATA} -n=admin -p=p@ssw0rd -r=admin \
       && /mc-start.sh \
      "]


### PR DESCRIPTION
> Unmatched arguments from index 0: 'create-user', '-H=/data', '-n=admin', '-p=p@ssw0rd', '-r=admin'
> Did you mean: user or cluster or active-directory?

I faced with the issue when I try to run **management-center-built-in-user** 